### PR TITLE
changed to use DP instead of custom backing field

### DIFF
--- a/Making.Cents.Wpf.Common/Behaviors/IsVisibleChangedBehavior.cs
+++ b/Making.Cents.Wpf.Common/Behaviors/IsVisibleChangedBehavior.cs
@@ -13,14 +13,12 @@ namespace Making.Cents.Wpf.Common.Behaviors
 	public partial class IsVisibleChangedBehavior : Behavior<UserControl>
 	{
 		public static readonly DependencyProperty CommandProperty =
-			Gen.Command<ICommand>();
+			Gen.Command<ICommand?>();
 
-		private ICommand? _command;
 		private static void CommandPropertyChanged(
 			IsVisibleChangedBehavior self,
 			DependencyPropertyChangedEventArgs e)
 		{
-			self._command = e.NewValue as ICommand;
 			self.Update();
 		}
 
@@ -46,9 +44,9 @@ namespace Making.Cents.Wpf.Common.Behaviors
 		private bool _currentStatus = false;
 		private void Update(bool newValue)
 		{
-			if (newValue != _currentStatus && _command != null)
+			if (newValue != _currentStatus)
 			{
-				_command.Execute(newValue);
+				Command?.Execute(newValue);
 				_currentStatus = newValue;
 			}
 		}


### PR DESCRIPTION
When using BPZ for Dependency Properties, an instance property has been generated for you - in this case, the `Command` property.
As such, there's no need to declare a field to store the DP's value;
we can simply use the instance property that was generated for us.